### PR TITLE
Fix conflicts, include package.json to make yarn happy

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,6 @@ Priority: optional
 Depends: ${misc:Depends}, relaycore
 Pre-Depends: dpkg (>= 1.16.1), nodejs (>=20), ${misc:Pre-Depends}
 Provides: robot-ui
-Conflicts: robot-ui, r2c2-ui
-Replaces: robot-ui, r2c2-ui
+Conflicts: robot-ui, r2c2-ui, relaycore-ui
+Replaces: robot-ui, r2c2-ui, relaycore-ui
 Description: Web UI for RelayCore

--- a/debian/install
+++ b/debian/install
@@ -2,6 +2,7 @@ next.config.js /opt/robot-ui/
 next-env.d.ts /opt/robot-ui/
 tsconfig.json /opt/robot-ui/
 yarn.lock /opt/robot-ui/
+package.json /opt/robot-ui/
 node_modules/ /opt/robot-ui/
 public/ /opt/robot-ui/
 src/ /opt/robot-ui/


### PR DESCRIPTION
Conflict with other UI packages (including itself so crossgrades from PR to stable and vice versa works). Include package.json, because yarn demands it at runtime.