### PR TITLE
Add .yarnrc.yml, because of course the key configuration is in a hidden file

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -3,6 +3,7 @@ next-env.d.ts /opt/robot-ui/
 tsconfig.json /opt/robot-ui/
 yarn.lock /opt/robot-ui/
 package.json /opt/robot-ui/
+.yarnrc.yml /opt/robot-ui/
 node_modules/ /opt/robot-ui/
 public/ /opt/robot-ui/
 src/ /opt/robot-ui/


### PR DESCRIPTION
Probably fixes the package so it actually starts.